### PR TITLE
Change alcohol aging to require a full barrel

### DIFF
--- a/src/main/resources/data/tfcagedalcohol/recipe/barrel/aged_beer.json
+++ b/src/main/resources/data/tfcagedalcohol/recipe/barrel/aged_beer.json
@@ -3,11 +3,11 @@
   "type": "tfc:barrel_sealed",
   "input_fluid": {
     "fluid": "tfc:beer",
-    "amount": 100
+    "amount": 10000
   },
   "output_fluid": {
     "id": "tfcagedalcohol:aged_beer",
-    "amount": 100
+    "amount": 10000
   },
   "duration": 691200
 }

--- a/src/main/resources/data/tfcagedalcohol/recipe/barrel/aged_cider.json
+++ b/src/main/resources/data/tfcagedalcohol/recipe/barrel/aged_cider.json
@@ -3,11 +3,11 @@
   "type": "tfc:barrel_sealed",
   "input_fluid": {
     "fluid": "tfc:cider",
-    "amount": 100
+    "amount": 10000
   },
   "output_fluid": {
     "id": "tfcagedalcohol:aged_cider",
-    "amount": 100
+    "amount": 10000
   },
   "duration": 691200
 }

--- a/src/main/resources/data/tfcagedalcohol/recipe/barrel/aged_corn_whiskey.json
+++ b/src/main/resources/data/tfcagedalcohol/recipe/barrel/aged_corn_whiskey.json
@@ -3,11 +3,11 @@
   "type": "tfc:barrel_sealed",
   "input_fluid": {
     "fluid": "tfc:corn_whiskey",
-    "amount": 100
+    "amount": 10000
   },
   "output_fluid": {
     "id": "tfcagedalcohol:aged_corn_whiskey",
-    "amount": 100
+    "amount": 10000
   },
   "duration": 691200
 }

--- a/src/main/resources/data/tfcagedalcohol/recipe/barrel/aged_mead.json
+++ b/src/main/resources/data/tfcagedalcohol/recipe/barrel/aged_mead.json
@@ -3,11 +3,11 @@
   "type": "tfc:barrel_sealed",
   "input_fluid": {
     "fluid": "firmalife:mead",
-    "amount": 100
+    "amount": 10000
   },
   "output_fluid": {
     "id": "tfcagedalcohol:aged_mead",
-    "amount": 100
+    "amount": 10000
   },
   "duration": 691200,
   "neoforge:conditions": [

--- a/src/main/resources/data/tfcagedalcohol/recipe/barrel/aged_rum.json
+++ b/src/main/resources/data/tfcagedalcohol/recipe/barrel/aged_rum.json
@@ -3,11 +3,11 @@
   "type": "tfc:barrel_sealed",
   "input_fluid": {
     "fluid": "tfc:rum",
-    "amount": 100
+    "amount": 10000
   },
   "output_fluid": {
     "id": "tfcagedalcohol:aged_rum",
-    "amount": 100
+    "amount": 10000
   },
   "duration": 691200
 }

--- a/src/main/resources/data/tfcagedalcohol/recipe/barrel/aged_rye_whiskey.json
+++ b/src/main/resources/data/tfcagedalcohol/recipe/barrel/aged_rye_whiskey.json
@@ -3,11 +3,11 @@
   "type": "tfc:barrel_sealed",
   "input_fluid": {
     "fluid": "tfc:rye_whiskey",
-    "amount": 100
+    "amount": 10000
   },
   "output_fluid": {
     "id": "tfcagedalcohol:aged_rye_whiskey",
-    "amount": 100
+    "amount": 10000
   },
   "duration": 691200
 }

--- a/src/main/resources/data/tfcagedalcohol/recipe/barrel/aged_sake.json
+++ b/src/main/resources/data/tfcagedalcohol/recipe/barrel/aged_sake.json
@@ -3,11 +3,11 @@
   "type": "tfc:barrel_sealed",
   "input_fluid": {
     "fluid": "tfc:sake",
-    "amount": 100
+    "amount": 10000
   },
   "output_fluid": {
     "id": "tfcagedalcohol:aged_sake",
-    "amount": 100
+    "amount": 10000
   },
   "duration": 691200
 }

--- a/src/main/resources/data/tfcagedalcohol/recipe/barrel/aged_vodka.json
+++ b/src/main/resources/data/tfcagedalcohol/recipe/barrel/aged_vodka.json
@@ -3,11 +3,11 @@
   "type": "tfc:barrel_sealed",
   "input_fluid": {
     "fluid": "tfc:vodka",
-    "amount": 100
+    "amount": 10000
   },
   "output_fluid": {
     "id": "tfcagedalcohol:aged_vodka",
-    "amount": 100
+    "amount": 10000
   },
   "duration": 691200
 }

--- a/src/main/resources/data/tfcagedalcohol/recipe/barrel/aged_whiskey.json
+++ b/src/main/resources/data/tfcagedalcohol/recipe/barrel/aged_whiskey.json
@@ -3,11 +3,11 @@
   "type": "tfc:barrel_sealed",
   "input_fluid": {
     "fluid": "tfc:whiskey",
-    "amount": 100
+    "amount": 10000
   },
   "output_fluid": {
     "id": "tfcagedalcohol:aged_whiskey",
-    "amount": 100
+    "amount": 10000
   },
   "duration": 691200
 }


### PR DESCRIPTION
Altered the aged alcohol recipes so that they require a full (10,000mB) barrel of liquid before aging will start. Partially-filled barrels can now be used to create vinegar, fixing Issue #11 